### PR TITLE
Add clip-path

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ module.exports = {
     ],
     [
       "clip",
+      "clip-path",
       "zoom"
     ],
     [


### PR DESCRIPTION
This adds [`clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path), which replaces the deprecated `clip`.