### PR TITLE
Add overscroll-behavior properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,13 @@ module.exports = {
       "overflow-y"
     ],
     [
+      "overscroll-behavior",
+      "overscroll-behavior-x",
+      "overscroll-behavior-y",
+      "overscroll-behavior-block",
+      "overscroll-behavior-inline"
+    ],
+    [
       "clip",
       "zoom"
     ],


### PR DESCRIPTION
Adds [`overscroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) and its variants.